### PR TITLE
Update README to include more links and up-to-date information

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,5 @@ MAX_PLAYERS=10
 MAP=/levels/gridmap_v2/info.json
 NAME=BeamMP New Server
 DESC=BeamMP Default Description
+PORT=30814
 AUTH_KEY=

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,10 +64,6 @@ RUN addgroup -g 1000 -S beammp && adduser -u 1000 -S beammp -G beammp
 RUN chown -R beammp:beammp . && chmod -R 775 .
 USER beammp
 
-# We need tcp and udp
-EXPOSE 30814/tcp
-EXPOSE 30814/udp
-
 # Specify entrypoint
 COPY entrypoint.sh /
 ENTRYPOINT /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ The sections below provides use cases for docker and docker-compose.
 Quick start:
 
 ```bash
-docker run --name beammp-server -p 30814:30814/tcp -p 30814:30814/udp \
+docker run --name beammp-server \
+           -p 30814:30814/tcp -p 30814:30814/udp \
            -e NAME='My first awesome Server' \
            -e AUTH_KEY='<insert auth-key>' \
-           rouhim/beammp-server:latest
+           rouhim/beammp-server
 ```
 
 ### docker-compose
@@ -48,7 +49,8 @@ docker-compose pull && docker-compose up -d
 
 Variable name   | description                                                                                   | default value
 --------------- |---------------------------------------------------------------------------------------------- | -------- 
-AUTH_KEY        | **Mandatory!** The authentication key used by the server. It is used to identify your server and is not optional.| empty
+AUTH_KEY        | **
+Mandatory!** The authentication key used by the server. It is used to identify your server and is not optional.| empty
 DEBUG           | Set to true to enable debug output in the console                                             | false
 PRIVATE         | Set to true if you don't want to show up in the Server Browser                                | true
 CARS            | How many vehicles a player is allowed to have at the same time                                | 1
@@ -56,9 +58,12 @@ MAX_PLAYER      | How many players your server can hold at a time               
 MAP             | What the server map is                                                                        | /levels/gridmap_v2/info.json
 NAME            | What your server is called. This shows up in the Server Browser                               | BeamMP New Server
 DESC            | What shows under the name when you click on the server                                        | BeamMP Default Description
-PORT            | Has to be the same as the host-port that the container is running on                          | 30814
+PORT            | This value must be identical to the containers exposed port.                                  | 30814
 
-A new AUTH_KEY can be claimed on [this site](https://beammp.com/k/dashboard), you will need a [Discord](https://discord.com) account for this. Note that the IP entered there does *not* matter, despite what the site claims. For more information refer to [this wiki page](https://wiki.beammp.com/en/home/server-installation#h-2-obtaining-an-authentication-key).
+A new AUTH_KEY can be claimed on [this site](https://beammp.com/k/dashboard), you will need
+a [Discord](https://discord.com) account for this. Note that the IP entered there does *not* matter, despite what the
+site claims. For more information refer
+to [this wiki page](https://wiki.beammp.com/en/home/server-installation#h-2-obtaining-an-authentication-key).
 
 ## Game mods
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ MAX_PLAYER      | How many players your server can hold at a time               
 MAP             | What the server map is                                                                        | /levels/gridmap_v2/info.json
 NAME            | What your server is called. This shows up in the Server Browser                               | BeamMP New Server
 DESC            | What shows under the name when you click on the server                                        | BeamMP Default Description
+PORT            | Has to be the same as the host-port that the container is running on                          
 
-A new AUTH_KEY can be claimed on their [discord server](https://beammp.com/k/dashboard). The key creation is done by
-using a discord plugin and requires not much effort. Each key is IP-bound so there can be only one key per IP.
+A new AUTH_KEY can be claimed on [this site](https://beammp.com/k/dashboard), you will need a [Discord](https://discord.com) account for this. Note that the IP entered there does *not* matter, despite what the site claims. For more information refer to [this wiki page](https://wiki.beammp.com/en/home/server-installation#h-2-obtaining-an-authentication-key).
 
 ## Game mods
 
@@ -96,6 +96,7 @@ unzip -l PATH/TO/MAP.zip \
 ## Used materials
 
 - BeamMP server repository: https://github.com/BeamMP/BeamMP-Server
+- Official server maintenance guide: https://wiki.beammp.com/en/home/server-maintenance
 - Official server installation guide: https://wiki.beammp.com/en/home/server-installation
 - Inspired by: https://github.com/mastamic-ian/BeamMP_docker
 - Built from: https://github.com/RouHim/beammp-docker

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ MAX_PLAYER      | How many players your server can hold at a time               
 MAP             | What the server map is                                                                        | /levels/gridmap_v2/info.json
 NAME            | What your server is called. This shows up in the Server Browser                               | BeamMP New Server
 DESC            | What shows under the name when you click on the server                                        | BeamMP Default Description
-PORT            | Has to be the same as the host-port that the container is running on                          
+PORT            | Has to be the same as the host-port that the container is running on                          | 30814
 
 A new AUTH_KEY can be claimed on [this site](https://beammp.com/k/dashboard), you will need a [Discord](https://discord.com) account for this. Note that the IP entered there does *not* matter, despite what the site claims. For more information refer to [this wiki page](https://wiki.beammp.com/en/home/server-installation#h-2-obtaining-an-authentication-key).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,11 +17,11 @@ services:
       - PORT
       - AUTH_KEY
     volumes:
-      # Simply slide any mod you want to add in that folder
+      # Just move all the mods you want to add into this folder
       - ./mods:/beammp/Resources/Client
     ports:
-      - "${PORT}:30814/tcp"
-      - "${PORT}:30814/udp"
+      - "${PORT}:${PORT}/tcp"
+      - "${PORT}:${PORT}/udp"
     logging:
       driver: "json-file"
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: rouhim/beammp-server
     build:
       context: .
-    environment:      
+    environment:
       # Game server parameter
       - PRIVATE
       - DEBUG
@@ -14,13 +14,14 @@ services:
       - MAP
       - NAME
       - DESC
+      - PORT
       - AUTH_KEY
     volumes:
       # Simply slide any mod you want to add in that folder
       - ./mods:/beammp/Resources/Client
     ports:
-      - 30814:30814/tcp
-      - 30814:30814/udp
+      - "${PORT}:30814/tcp"
+      - "${PORT}:30814/udp"
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
I noticed that documentation was missing on PORT and how to set that up. It has to be the same as the public-facing port the container is exposing on, since that's where the requests will go. The PORT configured in the ServerConfig.toml ends up being sent to the backend and put on the server list, so this is super important. 

Docker has no way (that I know of, at least) to ask for the host-port from inside the container, so this is quite important. 

If someone was to change the port on the container but not this setting, server-list joining would not work.

Also added the link to our new server-maintenance page on the wiki.